### PR TITLE
Release 2.1.0

### DIFF
--- a/.github/workflows/test.pkl
+++ b/.github/workflows/test.pkl
@@ -1,0 +1,5 @@
+extends "package://components.emilym.cl/actions/actions@0.1.14#/common/simple-gradle.pkl"
+
+jobName = "test"
+gradleTask = "jvmTest"
+name = "Test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+'on':
+  pull_request:
+    branches:
+    - main
+    - develop
+  push:
+    branches:
+    - main
+    - develop
+    - release/**
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module:
+        - requeststate
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: temurin
+    - name: Setup gradle
+      uses: gradle/actions/setup-gradle@v3
+    - name: Test with Gradle
+      env: {}
+      run: ./gradlew ${{ matrix.module }}:jvmTest

--- a/.github/workflows/workflows.pkl
+++ b/.github/workflows/workflows.pkl
@@ -19,4 +19,5 @@ workflows = new Listing {
         }
     }
     import("package://components.emilym.cl/actions/actions@0.1.13#/lint.pkl")
+    import("test.pkl")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,10 +17,14 @@ compose-plugin = "1.6.11"
 errorwidget = "2.0.2"
 units = "2.0.3"
 lifecycleLivedataCoreKtx = "2.8.7"
+mockk = "1.12.5"
+coroutines-test = "1.8.0"
 
 [libraries]
 androidx-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-test-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-test" }
+mockk-common = { module = "io.mockk:mockk-common", version.ref = "mockk" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }

--- a/requeststate/build.gradle.kts
+++ b/requeststate/build.gradle.kts
@@ -77,6 +77,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlin.test.coroutines)
         }
     }
 }

--- a/requeststate/src/commonMain/kotlin/cl/emilym/compose/requeststate/RequestState.kt
+++ b/requeststate/src/commonMain/kotlin/cl/emilym/compose/requeststate/RequestState.kt
@@ -4,10 +4,10 @@ sealed interface RequestState<T> {
 
     class Initial<T>: RequestState<T>
     class Loading<T>: RequestState<T>
-    class Success<T>(
+    data class Success<T>(
         val value: T
     ): RequestState<T>
-    class Failure<T>(
+    data class Failure<T>(
         val exception: Throwable
     ): RequestState<T>
 

--- a/requeststate/src/commonMain/kotlin/cl/emilym/compose/requeststate/RequestState.kt
+++ b/requeststate/src/commonMain/kotlin/cl/emilym/compose/requeststate/RequestState.kt
@@ -8,7 +8,7 @@ sealed interface RequestState<T> {
         val value: T
     ): RequestState<T>
     class Failure<T>(
-        val exception: Exception
+        val exception: Throwable
     ): RequestState<T>
 
 }

--- a/requeststate/src/commonMain/kotlin/cl/emilym/compose/requeststate/RequestStateFlow.kt
+++ b/requeststate/src/commonMain/kotlin/cl/emilym/compose/requeststate/RequestStateFlow.kt
@@ -108,6 +108,8 @@ internal abstract class AbstractRequestStateFlow<U, T>: RequestStateFlow<T> {
                     block(this, up)
                 }
             }
+        }.catch {
+            emit(RequestState.Failure(it))
         }.collect(collector)
 }
 

--- a/requeststate/src/commonMain/kotlin/cl/emilym/compose/requeststate/RequestStateFlow.kt
+++ b/requeststate/src/commonMain/kotlin/cl/emilym/compose/requeststate/RequestStateFlow.kt
@@ -7,15 +7,11 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flatMap
-import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.onStart
 
 /**
  * Create a RequestStateFlow for a retry-able operation that emits a single output

--- a/requeststate/src/commonMain/kotlin/cl/emilym/compose/requeststate/RequestStateFlow.kt
+++ b/requeststate/src/commonMain/kotlin/cl/emilym/compose/requeststate/RequestStateFlow.kt
@@ -1,0 +1,72 @@
+package cl.emilym.compose.requeststate
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.mapLatest
+
+/**
+ * @param operation The retry-able operation
+ */
+fun <T> requestStateFlow(operation: suspend () -> Flow<T>): RequestStateFlow<T> {
+    return DefaultRequestStateFlow(
+        flowOf(Unit),
+    ) {
+        operation()
+    }
+}
+
+/**
+ * @param operation The retry-able operation
+ * @receiver An upstream flow who's value is passed to the retry-able operation
+ */
+fun <U,T> Flow<U>.requestStateFlow(operation: suspend (U) -> Flow<T>): RequestStateFlow<T> {
+    return DefaultRequestStateFlow(
+        this,
+        operation
+    )
+}
+
+interface RequestStateFlow<T>: Flow<RequestState<T>> {
+
+    suspend fun retry()
+
+}
+
+internal class DefaultRequestStateFlow<U,T> internal constructor(
+    private val upstream: Flow<U>,
+    private val operation: suspend (U) -> Flow<T>
+): RequestStateFlow<T> {
+
+    private val retryTrigger = Channel<Unit>(Channel.CONFLATED).also { it.trySend(Unit) }
+
+    override suspend fun retry() {
+        retryTrigger.send(Unit)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override suspend fun collect(collector: FlowCollector<RequestState<T>>) =
+        upstream.flatMapLatest { up ->
+            retryTrigger.consumeAsFlow()
+                .flatMapLatest {
+                    flow<RequestState<T>> {
+                        emit(RequestState.Loading())
+                        emitAll(
+                            operation(up).mapLatest {
+                                RequestState.Success(it)
+                            }.catch {
+                                emit(RequestState.Failure(it))
+                            }
+                        )
+                    }
+                }
+        }.collect(collector)
+
+}

--- a/requeststate/src/commonMain/kotlin/cl/emilym/compose/requeststate/RequestStateWidget.kt
+++ b/requeststate/src/commonMain/kotlin/cl/emilym/compose/requeststate/RequestStateWidget.kt
@@ -23,7 +23,7 @@ fun <T> RequestStateWidget(
         failure = { exception ->
             Column(Modifier.padding(1.rdp)) {
                 ErrorWidget(
-                    exception,
+                    (exception as? Exception) ?: Exception(exception) ,
                     null,
                     retry
                 )
@@ -38,7 +38,7 @@ fun <T> RequestStateWidget(
     state: RequestState<T>,
     initial: @Composable () -> Unit,
     loading: @Composable () -> Unit,
-    failure: @Composable (Exception) -> Unit,
+    failure: @Composable (Throwable) -> Unit,
     success: @Composable (T) -> Unit
 ) {
     when (state) {

--- a/requeststate/src/commonTest/kotlin/cl/emilym/compose/requeststate/RequestStateFlowTest.kt
+++ b/requeststate/src/commonTest/kotlin/cl/emilym/compose/requeststate/RequestStateFlowTest.kt
@@ -1,0 +1,103 @@
+package cl.emilym.compose.requeststate
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.retry
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class RequestStateFlowTest {
+
+    @Test
+    fun single_request_state_flow_emits_success() = runTest {
+        val operation: suspend () -> String = { "Result" }
+        val flow = requestStateFlow(operation = operation)
+
+        val emissions = flow.toList()
+
+        assertEquals(2, emissions.size)
+        assertIs<RequestState.Loading<String>>(emissions[0])
+        assertIs<RequestState.Success<String>>(emissions[1])
+        assertEquals("Result", (emissions[1] as RequestState.Success).value)
+    }
+
+    @Test
+    fun single_request_state_flow_emits_failure_on_exception() = runTest {
+        val exception = RuntimeException("Error")
+        val operation: suspend () -> String = { throw exception }
+        val flow = requestStateFlow(operation = operation)
+
+        val emissions = flow.toList()
+
+        assertEquals(2, emissions.size)
+        assertIs<RequestState.Loading<String>>(emissions[0])
+        assertIs<RequestState.Failure<String>>(emissions[1])
+        assertEquals(exception, (emissions[1] as RequestState.Failure).exception)
+    }
+
+    @Test
+    fun flat_request_state_flow_emits_multiple_values() = runTest {
+        val operation: suspend () -> Flow<Int> = { flowOf(1, 2, 3) }
+        val flow = flatRequestStateFlow(operation = operation)
+
+        val emissions = flow.toList()
+
+        assertEquals(4, emissions.size)
+        assertIs<RequestState.Loading<Int>>(emissions[0])
+        assertEquals(listOf(1, 2, 3), emissions.drop(1).map { (it as RequestState.Success).value })
+    }
+
+    @Test
+    fun flow_upstream_propagates_values_to_request_state_flow() = runTest {
+        val upstream = flowOf(1, 2, 3)
+        val operation: suspend (Int) -> String = { "Processed: $it" }
+        val flow = upstream.requestStateFlow(operation = operation)
+
+        val emissions = flow.toList()
+
+        assertEquals(6, emissions.size) // 3 Loading + 3 Success
+        assertEquals("Processed: 1", (emissions[1] as RequestState.Success).value)
+        assertEquals("Processed: 2", (emissions[3] as RequestState.Success).value)
+        assertEquals("Processed: 3", (emissions[5] as RequestState.Success).value)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun retry_triggers_operation_again() = runTest {
+        val mockOperation: suspend () -> String = suspend { "Result" }
+        val flow = requestStateFlow(operation = mockOperation)
+
+        val emissions = mutableListOf<RequestState<String>>()
+        val job = flow
+            .onEach { emissions.add(it) }
+            .launchIn(this)
+
+        advanceUntilIdle()
+        flow.retry()
+        advanceUntilIdle()
+        job.cancel()
+
+        assertEquals(4, emissions.size)
+        assertIs<RequestState.Loading<String>>(emissions[0])
+        assertIs<RequestState.Success<String>>(emissions[1])
+        assertIs<RequestState.Loading<String>>(emissions[2])
+        assertIs<RequestState.Success<String>>(emissions[3])
+    }
+}

--- a/requeststate/src/commonTest/kotlin/cl/emilym/compose/requeststate/RequestStateFlowTest.kt
+++ b/requeststate/src/commonTest/kotlin/cl/emilym/compose/requeststate/RequestStateFlowTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.assertIs
 
 class RequestStateFlowTest {
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun single_request_state_flow_emits_success() = runTest {
         val operation: suspend () -> String = { "Result" }
@@ -33,6 +34,7 @@ class RequestStateFlowTest {
         assertEquals("Result", (emissions[1] as RequestState.Success).value)
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun single_request_state_flow_emits_failure_on_exception() = runTest {
         val exception = RuntimeException("Error")
@@ -52,6 +54,7 @@ class RequestStateFlowTest {
         assertEquals(exception, (emissions[1] as RequestState.Failure).exception)
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun flat_request_state_flow_emits_multiple_values() = runTest {
         val operation: suspend () -> Flow<Int> = { flowOf(1, 2, 3) }
@@ -69,6 +72,7 @@ class RequestStateFlowTest {
         assertEquals(listOf(1, 2, 3), emissions.drop(1).map { (it as RequestState.Success).value })
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun flow_upstream_propagates_values_to_request_state_flow() = runTest {
         val upstream = flow {

--- a/requeststate/src/commonTest/kotlin/cl/emilym/compose/requeststate/RequestStateFlowTest.kt
+++ b/requeststate/src/commonTest/kotlin/cl/emilym/compose/requeststate/RequestStateFlowTest.kt
@@ -131,12 +131,16 @@ class RequestStateFlowTest {
         advanceUntilIdle()
         flow.retry()
         advanceUntilIdle()
+        flow.retry()
+        advanceUntilIdle()
         job.cancel()
 
-        assertEquals(4, emissions.size)
+        assertEquals(6, emissions.size)
         assertIs<RequestState.Loading<String>>(emissions[0])
         assertIs<RequestState.Success<String>>(emissions[1])
         assertIs<RequestState.Loading<String>>(emissions[2])
         assertIs<RequestState.Success<String>>(emissions[3])
+        assertIs<RequestState.Loading<String>>(emissions[4])
+        assertIs<RequestState.Success<String>>(emissions[5])
     }
 }


### PR DESCRIPTION
* Support representation of `Throwable`, not just `Exception`
* Introduce a better interface for representing a RequestState flow (i.e. `RequestStateFlow`)